### PR TITLE
Add codegen for reset() method

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -107,6 +107,16 @@ func TestEncodeAndDecode(t *testing.T) {
 		},
 	}
 	assert.Truef(t, proto.Equal(&expected, &decoded), "expected equal\n\t%s\n\t%s", expected.String(), decoded.String())
+
+	newBytesBuf := bytes.NewBuffer(nil)
+	builder.Reset(newBytesBuf)
+	builder.SetX(1)
+
+	proto.Unmarshal(newBytesBuf.Bytes(), &decoded)
+	newExpected := &pb.Thing{
+		X: 1,
+	}
+	assert.Truef(t, proto.Equal(newExpected, &decoded), "expected equal\n\t%s\n\t%s", expected.String(), decoded.String())
 }
 
 var sink any

--- a/main.go
+++ b/main.go
@@ -62,11 +62,20 @@ func handleDescriptor(outFile *FileContext, prefix string, message *descriptorpb
 
 	outFile.P("}") // end builder struct definition
 
+	// start constructor
 	outFile.P("func ", constructorName, "(writer io.Writer) *", builderTypeName, "{")
 	outFile.P("return &", builderTypeName, "{")
 	outFile.P("writer: writer,")
 	outFile.P("}")
 	outFile.P("}")
+	// end constructor
+
+	// start Reset() method
+	outFile.P("func (x *", builderTypeName, ") Reset(writer io.Writer) {")
+	outFile.P("x.buf.Reset()")
+	outFile.P("x.writer = writer")
+	outFile.P("}")
+	// end Reset() method
 
 	for _, field := range message.Field {
 		funcPrefix := "func(x *" + builderTypeName + ") "


### PR DESCRIPTION
Allows builders to be re-used. This is valuable because the underlying byte buffers in a builder can be shared between uses.  