### PR TITLE
Add support for more integer types 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ example/pb
 protoc-gen-gostreamer
 
 .idea/
+testdata/fuzz/

--- a/example/foo.proto
+++ b/example/foo.proto
@@ -21,6 +21,14 @@ message Thing2 {
   bytes  rawMessage = 10;
 
   repeated int32  myIntegers = 11;
+
+  fixed32 myFixed32 = 12;
+
+  sfixed32 mySfixed32 = 13;
+
+
+  sint32 mySint32 = 14;
+  sint64  mySint64 = 15;
 }
 
 message Thing {


### PR DESCRIPTION
The following types were not supported: sint32, sint64, sfixed32, sfixed64. These all have special encodings described at https://protobuf.dev/programming-guides/encoding/

This happens to fix a bug related to `float` which was incorrectly being represented as a varint, when it should have been a fixed 32